### PR TITLE
Issue 16

### DIFF
--- a/lib/matplotlib/tests/test_streamplot_klara.py
+++ b/lib/matplotlib/tests/test_streamplot_klara.py
@@ -5,13 +5,6 @@ import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import image_comparison
 import matplotlib.transforms as mtransforms
 import matplotlib.lines as mlines 
-
-def test_streamplot_zorder_not_none(): 
-    zord = mlines.Line2D.zorder 
-    with pytest.raises(ValueError) as excinfo:
-        plt.streamplot(np.arange(3), np.arange(3),
-                       np.full((3, 3), np.nan), np.full((3, 3), np.nan),
-                       color=np.random.rand(3, 3), zorder=zord)
     
 def test_streamplot_color_grid_shapes_not_matching():
     with pytest.raises(ValueError) as excinfo:
@@ -38,5 +31,5 @@ def test_streamplot_():
     with pytest.raises(ValueError) as excinfo:
         plt.streamplot(np.arange(3), np.arange(3),
                        np.full((3, 3), np.nan), np.full((3, 3), np.nan),
-                       color=np.random.rand(3, 3), start_points=np.full((3, 3), 10))
-    assert str(excinfo.value) == "Starting point (10, 10) outside of data boundaries"
+                       color=np.random.rand(3, 3), start_points=np.full((3, 2), 10))
+    assert str(excinfo.value) == "Starting point (10.0, 10.0) outside of data boundaries"

--- a/lib/matplotlib/tests/test_streamplot_klara.py
+++ b/lib/matplotlib/tests/test_streamplot_klara.py
@@ -1,0 +1,42 @@
+import numpy as np
+from numpy.testing import assert_array_almost_equal
+import pytest
+import matplotlib.pyplot as plt
+from matplotlib.testing.decorators import image_comparison
+import matplotlib.transforms as mtransforms
+import matplotlib.lines as mlines 
+
+def test_streamplot_zorder_not_none(): 
+    zord = mlines.Line2D.zorder 
+    with pytest.raises(ValueError) as excinfo:
+        plt.streamplot(np.arange(3), np.arange(3),
+                       np.full((3, 3), np.nan), np.full((3, 3), np.nan),
+                       color=np.random.rand(3, 3), zorder=zord)
+    
+def test_streamplot_color_grid_shapes_not_matching():
+    with pytest.raises(ValueError) as excinfo:
+        plt.streamplot(np.arange(3), np.arange(3),
+                       np.full((3, 3), np.nan), np.full((3, 3), np.nan),
+                       color=np.random.rand(5, 5))
+    assert str(excinfo.value) == "If 'color' is given, it must match the shape of the (x, y) grid"
+
+def test_streamplot_linewidth_grid_shape_not_matching():
+    with pytest.raises(ValueError) as excinfo:
+        plt.streamplot(np.arange(3), np.arange(3),
+                       np.full((3, 3), np.nan), np.full((3, 3), np.nan),
+                       color=np.random.rand(3, 3), linewidth= np.full((5, 5), np.nan))
+    assert str(excinfo.value) == "If 'linewidth' is given, it must match the shape of the (x, y) grid"
+
+def test_streamplot_linewidth_check_u_grid_shape_not_matching():
+    with pytest.raises(ValueError) as excinfo:
+        plt.streamplot(np.arange(3), np.arange(3),
+                       np.full((5, 5), np.nan), np.full((3, 3), np.nan),
+                       color=np.random.rand(3, 3))
+    assert str(excinfo.value) == "'u' and 'v' must match the shape of the (x, y) grid"
+
+def test_streamplot_():
+    with pytest.raises(ValueError) as excinfo:
+        plt.streamplot(np.arange(3), np.arange(3),
+                       np.full((3, 3), np.nan), np.full((3, 3), np.nan),
+                       color=np.random.rand(3, 3), start_points=np.full((3, 3), 10))
+    assert str(excinfo.value) == "Starting point (10, 10) outside of data boundaries"


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
