### PR TITLE
Issue 15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,6 @@ lib/matplotlib/backends/web_backend/package-lock.json
 # DD2480 - Group 24 Venv #
 # Add your virtual environment folder name here #
 jonasvenv
-
+klaravenv
 
 LICENSE/LICENSE_QHULL

--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -10,6 +10,7 @@ from matplotlib import _api, cm, patches
 import matplotlib.colors as mcolors
 import matplotlib.collections as mcollections
 import matplotlib.lines as mlines
+from matplotlib.tests.conftest import streamBranchBools
 
 
 __all__ = ['streamplot']
@@ -93,16 +94,20 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
     dmap = DomainMap(grid, mask)
 
     if zorder is None:
+        streamBranchBools[0] = True
         zorder = mlines.Line2D.zorder
 
     # default to data coordinates
     if transform is None:
+        streamBranchBools[1] = True
         transform = axes.transData
-
+    
     if color is None:
+        streamBranchBools[2] = True
         color = axes._get_lines.get_next_color()
 
     if linewidth is None:
+        streamBranchBools[3] = True
         linewidth = mpl.rcParams['lines.linewidth']
 
     line_kw = {}
@@ -112,25 +117,32 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
                        integration_direction=integration_direction)
 
     if integration_direction == 'both':
+        streamBranchBools[4] = True
         maxlength /= 2.
 
     use_multicolor_lines = isinstance(color, np.ndarray)
     if use_multicolor_lines:
+        streamBranchBools[5] = True
         if color.shape != grid.shape:
+            streamBranchBools[6] = True
             raise ValueError("If 'color' is given, it must match the shape of "
                              "the (x, y) grid")
         line_colors = [[]]  # Empty entry allows concatenation of zero arrays.
         color = np.ma.masked_invalid(color)
     else:
+        streamBranchBools[7] = True
         line_kw['color'] = color
         arrow_kw['color'] = color
 
     if isinstance(linewidth, np.ndarray):
+        streamBranchBools[8] = True
         if linewidth.shape != grid.shape:
+            streamBranchBools[9] = True
             raise ValueError("If 'linewidth' is given, it must match the "
                              "shape of the (x, y) grid")
         line_kw['linewidth'] = []
     else:
+        streamBranchBools[10] = True
         line_kw['linewidth'] = linewidth
         arrow_kw['linewidth'] = linewidth
 
@@ -139,6 +151,7 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
 
     # Sanity checks.
     if u.shape != grid.shape or v.shape != grid.shape:
+        streamBranchBools[11] = True
         raise ValueError("'u' and 'v' must match the shape of the (x, y) grid")
 
     u = np.ma.masked_invalid(u)
@@ -149,19 +162,26 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
 
     trajectories = []
     if start_points is None:
+        streamBranchBools[12] = True
         for xm, ym in _gen_starting_points(mask.shape):
+            streamBranchBools[13] = True
             if mask[ym, xm] == 0:
+                streamBranchBools[14] = True
                 xg, yg = dmap.mask2grid(xm, ym)
                 t = integrate(xg, yg, broken_streamlines)
                 if t is not None:
+                    streamBranchBools[15] = True
                     trajectories.append(t)
     else:
+        streamBranchBools[16] = True
         sp2 = np.asanyarray(start_points, dtype=float).copy()
 
         # Check if start_points are outside the data boundaries
         for xs, ys in sp2:
+            streamBranchBools[17] = True
             if not (grid.x_origin <= xs <= grid.x_origin + grid.width and
                     grid.y_origin <= ys <= grid.y_origin + grid.height):
+                streamBranchBools[18] = True
                 raise ValueError(f"Starting point ({xs}, {ys}) outside of "
                                  "data boundaries")
 
@@ -172,6 +192,7 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
         sp2[:, 1] -= grid.y_origin
 
         for xs, ys in sp2:
+            streamBranchBools[19] = True
             xg, yg = dmap.data2grid(xs, ys)
             # Floating point issues can cause xg, yg to be slightly out of
             # bounds for xs, ys on the upper boundaries. Because we have
@@ -182,16 +203,20 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
 
             t = integrate(xg, yg, broken_streamlines)
             if t is not None:
+                streamBranchBools[20] = True
                 trajectories.append(t)
 
     if use_multicolor_lines:
+        streamBranchBools[21] = True
         if norm is None:
+            streamBranchBools[22] = True
             norm = mcolors.Normalize(color.min(), color.max())
         cmap = cm._ensure_cmap(cmap)
 
     streamlines = []
     arrows = []
     for t in trajectories:
+        streamBranchBools[23] = True
         tgx, tgy = t.T
         # Rescale from grid-coordinates to data-coordinates.
         tx, ty = dmap.grid2data(tgx, tgy)
@@ -200,9 +225,11 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
 
         # Create multiple tiny segments if varying width or color is given
         if isinstance(linewidth, np.ndarray) or use_multicolor_lines:
+            streamBranchBools[24] = True
             points = np.transpose([tx, ty]).reshape(-1, 1, 2)
             streamlines.extend(np.hstack([points[:-1], points[1:]]))
         else:
+            streamBranchBools[25] = True
             points = np.transpose([tx, ty])
             streamlines.append(points)
 
@@ -213,11 +240,13 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
         arrow_head = (np.mean(tx[n:n + 2]), np.mean(ty[n:n + 2]))
 
         if isinstance(linewidth, np.ndarray):
+            streamBranchBools[26] = True
             line_widths = interpgrid(linewidth, tgx, tgy)[:-1]
             line_kw['linewidth'].extend(line_widths)
             arrow_kw['linewidth'] = line_widths[n]
 
         if use_multicolor_lines:
+            streamBranchBools[27] = True
             color_values = interpgrid(color, tgx, tgy)[:-1]
             line_colors.append(color_values)
             arrow_kw['color'] = cmap(norm(color_values[n]))
@@ -231,6 +260,7 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
     lc.sticky_edges.x[:] = [grid.x_origin, grid.x_origin + grid.width]
     lc.sticky_edges.y[:] = [grid.y_origin, grid.y_origin + grid.height]
     if use_multicolor_lines:
+        streamBranchBools[27] = True
         lc.set_array(np.ma.hstack(line_colors))
         lc.set_cmap(cmap)
         lc.set_norm(norm)
@@ -239,6 +269,7 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
     ac = mcollections.PatchCollection(arrows)
     # Adding the collection itself is broken; see #2341.
     for p in arrows:
+        streamBranchBools[28] = True
         axes.add_patch(p)
 
     axes.autoscale_view()

--- a/lib/matplotlib/tests/conftest.py
+++ b/lib/matplotlib/tests/conftest.py
@@ -5,6 +5,7 @@ from matplotlib.testing.conftest import (  # noqa
 #Global boolean list declarations
 histBranchBools = [False for i in range(72)]
 #another list with false booleans
+histBranchBoolsKey = [False for i in range(23)]
 
 def writeRes():
     currTakenBranches = 0

--- a/lib/matplotlib/tests/conftest.py
+++ b/lib/matplotlib/tests/conftest.py
@@ -6,6 +6,7 @@ from matplotlib.testing.conftest import (  # noqa
 histBranchBools = [False for i in range(72)]
 #another list with false booleans
 histBranchBoolsKey = [False for i in range(23)]
+streamBranchBools = [False for i in range(28)]
 
 def writeRes():
     currTakenBranches = 0

--- a/lib/matplotlib/tests/conftest.py
+++ b/lib/matplotlib/tests/conftest.py
@@ -6,7 +6,7 @@ from matplotlib.testing.conftest import (  # noqa
 histBranchBools = [False for i in range(72)]
 #another list with false booleans
 histBranchBoolsKey = [False for i in range(23)]
-streamBranchBools = [False for i in range(28)]
+streamBranchBools = [False for i in range(29)]
 
 def writeRes():
     currTakenBranches = 0
@@ -22,6 +22,23 @@ def writeRes():
     f.write("||\n")
     f.write(f"The hist() function took {100*(currTakenBranches/len(histBranchBools))}% of its branches, {currTakenBranches} out of {len(histBranchBools)}, during the tests.")
     f.write("\n")
+
+    currTakenBranches = 0
+    global streamBranchBools
+    f = open("BranchCovRes.txt", "w")
+    for currBranchNr in range(len(streamBranchBools)):
+        if (currBranchNr % 4 == 0 and currBranchNr != 0):
+            f.write("||\n")
+        f.write(f"|| Branch {currBranchNr} taken: {streamBranchBools[currBranchNr]} ")
+        if (streamBranchBools[currBranchNr]):
+            currTakenBranches += 1
+
+    f.write("||\n")
+    f.write(
+        f"The hist() function took {100 * (currTakenBranches / len(streamBranchBools))}% of its branches, {currTakenBranches} out of {len(streamBranchBools)}, during the tests.")
+    f.write("\n")
+
+
     f.close()
 
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -13,6 +13,7 @@ from contextlib import ExitStack
 import copy
 import itertools
 from numbers import Integral, Number
+from matplotlib.tests.conftest import histBranchBoolsKey
 
 from cycler import cycler
 import numpy as np
@@ -1462,39 +1463,63 @@ class TextBox(AxesWidget):
 
     def _keypress(self, event):
         if self.ignore(event):
+            histBranchBoolsKey[0] = True
             return
+        histBranchBoolsKey[1] = True
         if self.capturekeystrokes:
+            histBranchBoolsKey[2] = True
             key = event.key
             text = self.text
             if len(key) == 1:
+                histBranchBoolsKey[4] = True
                 text = (text[:self.cursor_index] + key +
                         text[self.cursor_index:])
                 self.cursor_index += 1
             elif key == "right":
+                histBranchBoolsKey[5] = True
                 if self.cursor_index != len(text):
+                    histBranchBoolsKey[12] = True
                     self.cursor_index += 1
+                histBranchBoolsKey[13] = True
             elif key == "left":
+                histBranchBoolsKey[6] = True
                 if self.cursor_index != 0:
+                    histBranchBoolsKey[14] = True
                     self.cursor_index -= 1
+                histBranchBoolsKey[15] = True
             elif key == "home":
+                histBranchBoolsKey[7] = True
                 self.cursor_index = 0
             elif key == "end":
+                histBranchBoolsKey[8] = True
                 self.cursor_index = len(text)
             elif key == "backspace":
+                histBranchBoolsKey[9] = True
                 if self.cursor_index != 0:
+                    histBranchBoolsKey[16] = True
                     text = (text[:self.cursor_index - 1] +
                             text[self.cursor_index:])
                     self.cursor_index -= 1
+                histBranchBoolsKey[17] = True
             elif key == "delete":
+                histBranchBoolsKey[10] = True
                 if self.cursor_index != len(self.text):
+                    histBranchBoolsKey[18] = True
                     text = (text[:self.cursor_index] +
                             text[self.cursor_index + 1:])
+                histBranchBoolsKey[19] = True
+            histBranchBoolsKey[11] = True
             self.text_disp.set_text(text)
             self._rendercursor()
             if self.eventson:
+                histBranchBoolsKey[20] = True
                 self._observers.process('change', self.text)
                 if key in ["enter", "return"]:
+                    histBranchBoolsKey[22] = True
                     self._observers.process('submit', self.text)
+                histBranchBoolsKey[23] = True
+            histBranchBoolsKey[21] = True
+        histBranchBoolsKey[3] = True
 
     def set_val(self, val):
         newval = str(val)


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
