### PR TITLE
feat: refactored streamplot #28

### DIFF
--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -14,6 +14,77 @@ import matplotlib.lines as mlines
 
 __all__ = ['streamplot']
 
+def refactor1(mask, trajectories, dmap, integrate, broken_streamlines):
+    for xm, ym in _gen_starting_points(mask.shape):
+            if mask[ym, xm] == 0:
+                xg, yg = dmap.mask2grid(xm, ym)
+                t = integrate(xg, yg, broken_streamlines)
+                if t is not None:
+                    trajectories.append(t)
+
+def refactor2(start_points, grid, dmap, integrate, broken_streamlines, trajectories):
+    sp2 = np.asanyarray(start_points, dtype=float).copy()
+
+    # Check if start_points are outside the data boundaries
+    for xs, ys in sp2:
+        if not (grid.x_origin <= xs <= grid.x_origin + grid.width and
+                grid.y_origin <= ys <= grid.y_origin + grid.height):
+            raise ValueError(f"Starting point ({xs}, {ys}) outside of "
+                                "data boundaries")
+
+    # Convert start_points from data to array coords
+    # Shift the seed points from the bottom left of the data so that
+    # data2grid works properly.
+    sp2[:, 0] -= grid.x_origin
+    sp2[:, 1] -= grid.y_origin
+
+    for xs, ys in sp2:
+        xg, yg = dmap.data2grid(xs, ys)
+        # Floating point issues can cause xg, yg to be slightly out of
+        # bounds for xs, ys on the upper boundaries. Because we have
+        # already checked that the starting points are within the original
+        # grid, clip the xg, yg to the grid to work around this issue
+        xg = np.clip(xg, 0, grid.nx - 1)
+        yg = np.clip(yg, 0, grid.ny - 1)
+
+        t = integrate(xg, yg, broken_streamlines)
+        if t is not None:
+            trajectories.append(t)
+
+def refactor3(t, dmap, grid, linewidth, use_multicolor_lines, streamlines, line_kw, arrow_kw, line_colors, color, cmap, norm, transform, arrows):
+    tgx, tgy = t.T
+    # Rescale from grid-coordinates to data-coordinates.
+    tx, ty = dmap.grid2data(tgx, tgy)
+    tx += grid.x_origin
+    ty += grid.y_origin
+
+    # Create multiple tiny segments if varying width or color is given
+    if isinstance(linewidth, np.ndarray) or use_multicolor_lines:
+        points = np.transpose([tx, ty]).reshape(-1, 1, 2)
+        streamlines.extend(np.hstack([points[:-1], points[1:]]))
+    else:
+        points = np.transpose([tx, ty])
+        streamlines.append(points)
+
+    # Add arrows halfway along each trajectory.
+    s = np.cumsum(np.hypot(np.diff(tx), np.diff(ty)))
+    n = np.searchsorted(s, s[-1] / 2.)
+    arrow_tail = (tx[n], ty[n])
+    arrow_head = (np.mean(tx[n:n + 2]), np.mean(ty[n:n + 2]))
+
+    if isinstance(linewidth, np.ndarray):
+        line_widths = interpgrid(linewidth, tgx, tgy)[:-1]
+        line_kw['linewidth'].extend(line_widths)
+        arrow_kw['linewidth'] = line_widths[n]
+
+    if use_multicolor_lines:
+        color_values = interpgrid(color, tgx, tgy)[:-1]
+        line_colors.append(color_values)
+        arrow_kw['color'] = cmap(norm(color_values[n]))
+
+    p = patches.FancyArrowPatch(
+        arrow_tail, arrow_head, transform=transform, **arrow_kw)
+    arrows.append(p)
 
 def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
                cmap=None, norm=None, arrowsize=1, arrowstyle='-|>',
@@ -149,41 +220,10 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
 
     trajectories = []
     if start_points is None:
-        for xm, ym in _gen_starting_points(mask.shape):
-            if mask[ym, xm] == 0:
-                xg, yg = dmap.mask2grid(xm, ym)
-                t = integrate(xg, yg, broken_streamlines)
-                if t is not None:
-                    trajectories.append(t)
+        refactor1(mask, trajectories, dmap, integrate, broken_streamlines)
     else:
-        sp2 = np.asanyarray(start_points, dtype=float).copy()
-
-        # Check if start_points are outside the data boundaries
-        for xs, ys in sp2:
-            if not (grid.x_origin <= xs <= grid.x_origin + grid.width and
-                    grid.y_origin <= ys <= grid.y_origin + grid.height):
-                raise ValueError(f"Starting point ({xs}, {ys}) outside of "
-                                 "data boundaries")
-
-        # Convert start_points from data to array coords
-        # Shift the seed points from the bottom left of the data so that
-        # data2grid works properly.
-        sp2[:, 0] -= grid.x_origin
-        sp2[:, 1] -= grid.y_origin
-
-        for xs, ys in sp2:
-            xg, yg = dmap.data2grid(xs, ys)
-            # Floating point issues can cause xg, yg to be slightly out of
-            # bounds for xs, ys on the upper boundaries. Because we have
-            # already checked that the starting points are within the original
-            # grid, clip the xg, yg to the grid to work around this issue
-            xg = np.clip(xg, 0, grid.nx - 1)
-            yg = np.clip(yg, 0, grid.ny - 1)
-
-            t = integrate(xg, yg, broken_streamlines)
-            if t is not None:
-                trajectories.append(t)
-
+        refactor2(start_points, grid, dmap, integrate, broken_streamlines, trajectories)
+    
     if use_multicolor_lines:
         if norm is None:
             norm = mcolors.Normalize(color.min(), color.max())
@@ -192,39 +232,7 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
     streamlines = []
     arrows = []
     for t in trajectories:
-        tgx, tgy = t.T
-        # Rescale from grid-coordinates to data-coordinates.
-        tx, ty = dmap.grid2data(tgx, tgy)
-        tx += grid.x_origin
-        ty += grid.y_origin
-
-        # Create multiple tiny segments if varying width or color is given
-        if isinstance(linewidth, np.ndarray) or use_multicolor_lines:
-            points = np.transpose([tx, ty]).reshape(-1, 1, 2)
-            streamlines.extend(np.hstack([points[:-1], points[1:]]))
-        else:
-            points = np.transpose([tx, ty])
-            streamlines.append(points)
-
-        # Add arrows halfway along each trajectory.
-        s = np.cumsum(np.hypot(np.diff(tx), np.diff(ty)))
-        n = np.searchsorted(s, s[-1] / 2.)
-        arrow_tail = (tx[n], ty[n])
-        arrow_head = (np.mean(tx[n:n + 2]), np.mean(ty[n:n + 2]))
-
-        if isinstance(linewidth, np.ndarray):
-            line_widths = interpgrid(linewidth, tgx, tgy)[:-1]
-            line_kw['linewidth'].extend(line_widths)
-            arrow_kw['linewidth'] = line_widths[n]
-
-        if use_multicolor_lines:
-            color_values = interpgrid(color, tgx, tgy)[:-1]
-            line_colors.append(color_values)
-            arrow_kw['color'] = cmap(norm(color_values[n]))
-
-        p = patches.FancyArrowPatch(
-            arrow_tail, arrow_head, transform=transform, **arrow_kw)
-        arrows.append(p)
+        refactor3(t, dmap, grid, linewidth, use_multicolor_lines, streamlines, line_kw, arrow_kw, line_colors, color, cmap, norm, transform, arrows)
 
     lc = mcollections.LineCollection(
         streamlines, transform=transform, **line_kw)


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
