### PR TITLE
Issue 24

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1,4 +1,5 @@
-from matplotlib.tests.conftest import histBranchBools
+from matplotlib.tests.conftest import boxplotlist
+
 
 import functools
 import itertools
@@ -3910,45 +3911,63 @@ class Axes(_AxesBase):
 
         # Missing arguments default to rcParams.
         if whis is None:
+            boxplotlist[0] = True
             whis = mpl.rcParams['boxplot.whiskers']
         if bootstrap is None:
+            boxplotlist[1] = True
             bootstrap = mpl.rcParams['boxplot.bootstrap']
 
         bxpstats = cbook.boxplot_stats(x, whis=whis, bootstrap=bootstrap,
                                        labels=labels, autorange=autorange)
         if notch is None:
+            boxplotlist[2] = True
             notch = mpl.rcParams['boxplot.notch']
         if vert is None:
+            boxplotlist[3] = True
             vert = mpl.rcParams['boxplot.vertical']
         if patch_artist is None:
+            boxplotlist[4] = True
             patch_artist = mpl.rcParams['boxplot.patchartist']
         if meanline is None:
+            boxplotlist[5] = True
             meanline = mpl.rcParams['boxplot.meanline']
         if showmeans is None:
+            boxplotlist[6] = True
             showmeans = mpl.rcParams['boxplot.showmeans']
         if showcaps is None:
+            boxplotlist[7] = True
             showcaps = mpl.rcParams['boxplot.showcaps']
         if showbox is None:
+            boxplotlist[8] = True
             showbox = mpl.rcParams['boxplot.showbox']
         if showfliers is None:
+            boxplotlist[9] = True
             showfliers = mpl.rcParams['boxplot.showfliers']
 
         if boxprops is None:
+            boxplotlist[10] = True
             boxprops = {}
         if whiskerprops is None:
+            boxplotlist[11] = True
             whiskerprops = {}
         if capprops is None:
+            boxplotlist[12] = True
             capprops = {}
         if medianprops is None:
+            boxplotlist[13] = True
             medianprops = {}
         if meanprops is None:
+            boxplotlist[14] = True
             meanprops = {}
         if flierprops is None:
+            boxplotlist[15] = True
             flierprops = {}
 
         if patch_artist:
+            boxplotlist[16] = True
             boxprops['linestyle'] = 'solid'  # Not consistent with bxp.
             if 'color' in boxprops:
+                boxplotlist[17] = True
                 boxprops['edgecolor'] = boxprops.pop('color')
 
         # if non-default sym value, put it into the flier dictionary
@@ -3957,24 +3976,29 @@ class Axes(_AxesBase):
         # handle all of the *sym* related logic here so we only have to pass
         # on the flierprops dict.
         if sym is not None:
+            boxplotlist[18] = True
             # no-flier case, which should really be done with
             # 'showfliers=False' but none-the-less deal with it to keep back
             # compatibility
             if sym == '':
+                boxplotlist[19] = True
                 # blow away existing dict and make one for invisible markers
                 flierprops = dict(linestyle='none', marker='', color='none')
                 # turn the fliers off just to be safe
                 showfliers = False
             # now process the symbol string
             else:
+                boxplotlist[20] = True
                 # process the symbol string
                 # discarded linestyle
                 _, marker, color = _process_plot_format(sym)
                 # if we have a marker, use it
                 if marker is not None:
+                    boxplotlist[21] = True
                     flierprops['marker'] = marker
                 # if we have a color, use it
                 if color is not None:
+                    boxplotlist[22] = True
                     # assume that if color is passed in the user want
                     # filled symbol, if the users want more control use
                     # flierprops
@@ -3984,30 +4008,44 @@ class Axes(_AxesBase):
 
         # replace medians if necessary:
         if usermedians is not None:
+            boxplotlist[23] = True
             if (len(np.ravel(usermedians)) != len(bxpstats) or
                     np.shape(usermedians)[0] != len(bxpstats)):
+                boxplotlist[24] = True
                 raise ValueError(
                     "'usermedians' and 'x' have different lengths")
             else:
+                boxplotlist[25] = True
                 # reassign medians as necessary
                 for stats, med in zip(bxpstats, usermedians):
+                    boxplotlist[26] = True
                     if med is not None:
+                        boxplotlist[27] = True
                         stats['med'] = med
 
         if conf_intervals is not None:
+            boxplotlist[28] = True
             if len(conf_intervals) != len(bxpstats):
+                boxplotlist[29] = True
                 raise ValueError(
                     "'conf_intervals' and 'x' have different lengths")
             else:
+                boxplotlist[30] = True
                 for stats, ci in zip(bxpstats, conf_intervals):
+                    boxplotlist[31] = True
                     if ci is not None:
+                        boxplotlist[32] = True
                         if len(ci) != 2:
+                            boxplotlist[33] = True
                             raise ValueError('each confidence interval must '
                                              'have two values')
                         else:
+                            boxplotlist[34] = True
                             if ci[0] is not None:
+                                boxplotlist[35] = True
                                 stats['cilo'] = ci[0]
                             if ci[1] is not None:
+                                boxplotlist[36] = True
                                 stats['cihi'] = ci[1]
 
         artists = self.bxp(bxpstats, positions=positions, widths=widths,

--- a/lib/matplotlib/tests/conftest.py
+++ b/lib/matplotlib/tests/conftest.py
@@ -6,7 +6,7 @@ from matplotlib.testing.conftest import (  # noqa
 #Global boolean list declarations
 histBranchBools = [False for i in range(72)]
 #another list with false booleans
-boxplotlist = [False for i in range(72)]
+boxplotlist = [False for i in range(36)]
 
 def writeRes():
     currTakenBranches = 0
@@ -22,6 +22,21 @@ def writeRes():
     
     f.write("||\n")
     f.write(f"The hist() function took {100*(currTakenBranches/len(histBranchBools))}% of its branches, {currTakenBranches} out of {len(histBranchBools)}, during the tests.")
+    f.write("\n")
+
+    currTakenBranches = 0
+    global boxplotlist
+    f = open("BranchCovRes.txt", "w")
+    for currBranchNr in range(len(boxplotlist)):
+        if (currBranchNr % 4 == 0 and currBranchNr != 0):
+            f.write("||\n")
+        f.write(f"|| Branch {currBranchNr} taken: {boxplotlist[currBranchNr]} ")
+        if (boxplotlist[currBranchNr]):
+            currTakenBranches += 1
+
+    f.write("||\n")
+    f.write(
+        f"The hist() function took {100 * (currTakenBranches / len(boxplotlist))}% of its branches, {currTakenBranches} out of {len(boxplotlist)}, during the tests.")
     f.write("\n")
     f.close()
 

--- a/lib/matplotlib/tests/conftest.py
+++ b/lib/matplotlib/tests/conftest.py
@@ -1,10 +1,12 @@
 
+
 from matplotlib.testing.conftest import (  # noqa
     mpl_test_settings, pytest_configure, pytest_unconfigure, pd, xr)
 
 #Global boolean list declarations
 histBranchBools = [False for i in range(72)]
 #another list with false booleans
+boxplotlist = [False for i in range(72)]
 
 def writeRes():
     currTakenBranches = 0
@@ -12,6 +14,7 @@ def writeRes():
     f = open("BranchCovRes.txt", "w")
     for currBranchNr in range(len(histBranchBools)):
         if(currBranchNr % 4 == 0 and currBranchNr != 0):
+
             f.write("||\n")
         f.write(f"|| Branch {currBranchNr} taken: {histBranchBools[currBranchNr]} ")
         if(histBranchBools[currBranchNr]):

--- a/lib/matplotlib/tests/func_boxplot.py
+++ b/lib/matplotlib/tests/func_boxplot.py
@@ -1,3 +1,4 @@
+from lib.matplotlib.cbook import boxplot_stats
 from matplotlib.tests.conftest import boxplotlist
 import functools
 import itertools
@@ -15,28 +16,27 @@ import io
 from itertools import product
 import platform
 from types import SimpleNamespace
-import dateutil.tz
 import numpy as np
 from numpy import ma
-from cycler import cycler
 import pytest
 
-boxprops = {'color': 'red'}
-boxplot = BoxPlot()
-boxplot.boxplot(x=[1,2,3,4], boxprops=boxprops)
-assert 'edgecolor' in boxprops
-assert boxprops['edgecolor'] == 'red'
-assert 'color' not in boxprops
+def test_boxplot_settings():
+    boxprops = {'color': 'red'}
+    sym = ''
+    flierprops = {'linestyle': 'none', 'marker': 'o', 'color': 'blue'}
+    showfliers = True
 
+    # Apply the boxplot settings
+    if 'color' in boxprops:
+        boxprops['edgecolor'] = boxprops.pop('color')
+    if sym == '':
+        flierprops = dict(linestyle='none', marker='', color='none')
+        showfliers = False
 
-sym = ''
-flierprops = {'linestyle': 'dashed', 'marker': '+', 'color': 'blue'}
-boxplot = BoxPlot()
-boxplot.boxplot(x=[1,2,3,4], sym=sym, flierprops=flierprops)
-assert 'linestyle' in flierprops
-assert flierprops['linestyle'] == 'none'
-assert 'marker' in flierprops
-assert flierprops['marker'] == ''
-assert 'color' in flierprops
-assert flierprops['color'] == 'none'
-assert showfliers is False
+    # Check that the boxprops were modified correctly
+    assert boxprops == {'edgecolor': 'red'}
+
+    # Check that the flierprops and showfliers were modified correctly
+    assert flierprops == {'linestyle': 'none', 'marker': '', 'color': 'none'}
+    assert showfliers == False
+

--- a/lib/matplotlib/tests/func_boxplot.py
+++ b/lib/matplotlib/tests/func_boxplot.py
@@ -1,11 +1,3 @@
-from lib.matplotlib.cbook import boxplot_stats
-from matplotlib.tests.conftest import boxplotlist
-import functools
-import itertools
-import logging
-import math
-from numbers import Integral, Number, Real
-
 import contextlib
 from collections import namedtuple
 import datetime
@@ -16,27 +8,48 @@ import io
 from itertools import product
 import platform
 from types import SimpleNamespace
+
+import dateutil.tz
+
 import numpy as np
 from numpy import ma
+from cycler import cycler
 import pytest
 
-def test_boxplot_settings():
-    boxprops = {'color': 'red'}
-    sym = ''
-    flierprops = {'linestyle': 'none', 'marker': 'o', 'color': 'blue'}
-    showfliers = True
+import matplotlib
+import matplotlib as mpl
+from matplotlib import rc_context
+from matplotlib._api import MatplotlibDeprecationWarning
+import matplotlib.colors as mcolors
+import matplotlib.dates as mdates
+from matplotlib.figure import Figure
+from matplotlib.axes import Axes
+import matplotlib.font_manager as mfont_manager
+import matplotlib.markers as mmarkers
+import matplotlib.patches as mpatches
+import matplotlib.path as mpath
+from matplotlib.projections.geo import HammerAxes
+from matplotlib.projections.polar import PolarAxes
+import matplotlib.pyplot as plt
+import matplotlib.text as mtext
+import matplotlib.ticker as mticker
+import matplotlib.transforms as mtransforms
+import mpl_toolkits.axisartist as AA
+from numpy.testing import (
+    assert_allclose, assert_array_equal, assert_array_almost_equal)
+from matplotlib.testing.decorators import (
+    image_comparison, check_figures_equal, remove_ticks_and_titles)
 
-    # Apply the boxplot settings
-    if 'color' in boxprops:
-        boxprops['edgecolor'] = boxprops.pop('color')
-    if sym == '':
-        flierprops = dict(linestyle='none', marker='', color='none')
-        showfliers = False
+def boxplot_test_empty_string():
+   data = np.random.rand(5,3)
+   fig, axs = plt.subplots(1)
+   axs[0].boxplot(data, sym = '')
+   
 
-    # Check that the boxprops were modified correctly
-    assert boxprops == {'edgecolor': 'red'}
+def boxplot_test_patchArtist_color():
+   data = np.random.rand(5,3)
+   fig, axs = plt.subplots(1)
+   axs[0].boxplot(data, boxprops=dict(facecolor='yellow', edgecolor='green', color='green', ls=':'))
 
-    # Check that the flierprops and showfliers were modified correctly
-    assert flierprops == {'linestyle': 'none', 'marker': '', 'color': 'none'}
-    assert showfliers == False
+
 

--- a/lib/matplotlib/tests/func_boxplot.py
+++ b/lib/matplotlib/tests/func_boxplot.py
@@ -1,0 +1,42 @@
+from matplotlib.tests.conftest import boxplotlist
+import functools
+import itertools
+import logging
+import math
+from numbers import Integral, Number, Real
+
+import contextlib
+from collections import namedtuple
+import datetime
+from decimal import Decimal
+from functools import partial
+import inspect
+import io
+from itertools import product
+import platform
+from types import SimpleNamespace
+import dateutil.tz
+import numpy as np
+from numpy import ma
+from cycler import cycler
+import pytest
+
+boxprops = {'color': 'red'}
+boxplot = BoxPlot()
+boxplot.boxplot(x=[1,2,3,4], boxprops=boxprops)
+assert 'edgecolor' in boxprops
+assert boxprops['edgecolor'] == 'red'
+assert 'color' not in boxprops
+
+
+sym = ''
+flierprops = {'linestyle': 'dashed', 'marker': '+', 'color': 'blue'}
+boxplot = BoxPlot()
+boxplot.boxplot(x=[1,2,3,4], sym=sym, flierprops=flierprops)
+assert 'linestyle' in flierprops
+assert flierprops['linestyle'] == 'none'
+assert 'marker' in flierprops
+assert flierprops['marker'] == ''
+assert 'color' in flierprops
+assert flierprops['color'] == 'none'
+assert showfliers is False


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
