### PR TITLE
doc: add ronan's contributions#39

### DIFF
--- a/Report.md
+++ b/Report.md
@@ -92,9 +92,9 @@ The `_apply_params()` function sets various properties of an axis in a matplotli
 
 ##### Ronan: 
 
-`Calc_label_rot_and_inline()`: Calculate the appropriate label rotation given the linecontour coordinates in screen units, the index of the label location and the label width. The method used here involves computing the path length along the contour in pixel coordinates and then looking approximately (label width / 2) away from central point to determine rotation and then to break contour if desired.
+`Calc_label_rot_and_inline()`: Calculate the appropriate label rotation given the linecontour coordinates in screen units, the index of the label location and the label width. The method used here involves computing the path length along the contour in pixel coordinates and then looking approximately (label width / 2) away from central point to determine rotation and then to break contour if desired. We have to check a lot of conditions thus the high complexity of the function.
 
-Subplot: adds subplot to a current figure at the specified grid position.  It is similar to the `subplots()` function however unlike `subplots()` it adds one subplot at a time. So to create multiple plots you will need several lines of code with the `subplot()` function.
+`Subplot()`: adds subplot to a current figure at the specified grid position.  It is similar to the `subplots()` function however unlike `subplots()` it adds one subplot at a time. So to create multiple plots you will need several lines of code with the `subplot()` function. The function had to check a lot of conditions too leading to a high complexity.
 
 
 
@@ -279,3 +279,5 @@ Pontus: (aiming for P+) Wrote 4 new tests for the function table() (table@654-83
 Ahmad: counted CCN by hand for _apply_params and plotbox() functions. In addition, implemented manual coverage for plotbox() functions. Wrote two tests for plotbox() and improved complexity. Also wrote the report with Klara, Jonas and Pontus.
 
 Jonas (aiming for P+): Counted CCN by hand for the subsuper() function, wrote the DIY branch coverage tool, implemented manual branch coverage for the hist() function, wrote four new tests for the hist() function to improve branch coverage from 81% to 88.9%, refactored the hist() function from CCN 77-42, wrote the report together with Klara, Pontus and Ahmad.
+
+Ronan: counted CCN by hand for subplot() and calc_label_rot_and_inline() functions. In addition, implemented manual coverage for subplot() function. Wrote a test for subplot().


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
