### PR TITLE
37 branch coverage

### DIFF
--- a/Report.md
+++ b/Report.md
@@ -216,7 +216,7 @@ Refactored the streamplot function to reduce the cyclomatic complexity from CNN 
 
 #### Ronan
 
-* Improved branch coverage of subplot() with one test case and of figure() with 3 new test cases.
+* Improved branch coverage of subplot() with one test case and of figure() with 3 new test cases. Subplot's coverage went from 88% to 100% and figure's coverage went from 40% to 73%.
 * Reduced the CCN from 22 -> 13 for the subplot function() wich is about 41 % reduction.
 
 
@@ -307,4 +307,9 @@ Ahmad: counted CCN by hand for _apply_params and plotbox() functions. In additio
 
 Jonas (aiming for P+): Counted CCN by hand for the subsuper() function, wrote the DIY branch coverage tool, implemented manual branch coverage for the hist() function, wrote four new tests for the hist() function to improve branch coverage from 81% to 88.9%, refactored the hist() function from CCN 77-42, wrote the report together with Klara, Pontus and Ahmad.
 
-Ronan (aiming for P+): counted CCN by hand for subplot() and figure() functions. In addition, implemented manual coverage for subplot() function. Wrote a test for subplot() and 3 for figure().
+Ronan (aiming for P+): 
+* Counted CCN by hand for subplot() and figure() functions. 
+* Implemented manual coverage for subplot() function.
+* Wrote a test for subplot() and 3 for figure().
+* Refactor subplot() function with 41% improvement.
+* Used the issue tracker and systematic commit messages.

--- a/Report.md
+++ b/Report.md
@@ -164,6 +164,11 @@ The complete results can be found [here](./lib/matplotlib/lizardResAfter.txt)
 57     17    431      8     108 get_tight_layout_figure@194-301@./_tight_layout.py
 //Pontus's new result
 47     10    346      8     114 get_tight_layout_figure@220-333@./_tight_layout.py
+
+//Ronan's old result:
+65     22    397      2     221 subplot@1129-1349@lib/matplotlib\pyplot.py
+//Ronan's new result:
+42     13    259      2     166 subplot@1170-1335@lib/matplotlib\pyplot.py
 ```
 
 #### Branch Coverage Improvement (P+):
@@ -209,8 +214,10 @@ Refactored the streamplot function to reduce the cyclomatic complexity from CNN 
 * Reduced the CCN from 17 -> 10 for the function get_tight_layout_figure() which is about 41% (get_tight_layout_figure@194-301@./_tight_layout.py) 
 * and improved branch coverage with 4 new tests for the function table() (table@654-830@./table.py) from 75% -> 89%
 
+#### Ronan
 
-
+* Improved branch coverage of subplot() with one test case and of figure() with 3 new test cases.
+* Reduced the CCN from 22 -> 13 for the subplot function() wich is about 41 % reduction.
 
 
 ## Coverage improvement

--- a/lib/matplotlib/BranchCovRes.txt
+++ b/lib/matplotlib/BranchCovRes.txt
@@ -32,6 +32,11 @@ The table() function took 89.28571428571429% of its branches, 25 out of 28, duri
 || Branch 16 taken: True || Branch 17 taken: True ||
 The subplot() function took 100.0% of its branches, 18 out of 18, during the tests.
 || Branch 0 taken: True || Branch 1 taken: True || Branch 2 taken: True || Branch 3 taken: True ||
+|| Branch 4 taken: True || Branch 5 taken: True || Branch 6 taken: False || Branch 7 taken: False ||
+|| Branch 8 taken: True || Branch 9 taken: False || Branch 10 taken: True || Branch 11 taken: True ||
+|| Branch 12 taken: True || Branch 13 taken: True || Branch 14 taken: False ||
+The figure() function took 73.33333333333333% of its branches, 11 out of 15, during the tests.
+|| Branch 0 taken: True || Branch 1 taken: True || Branch 2 taken: True || Branch 3 taken: True ||
 || Branch 4 taken: True || Branch 5 taken: True || Branch 6 taken: True || Branch 7 taken: True ||
 || Branch 8 taken: True || Branch 9 taken: True || Branch 10 taken: True || Branch 11 taken: True ||
 || Branch 12 taken: True || Branch 13 taken: True || Branch 14 taken: True || Branch 15 taken: True ||

--- a/lib/matplotlib/BranchCovResOld.txt
+++ b/lib/matplotlib/BranchCovResOld.txt
@@ -31,6 +31,11 @@ The table() function took 75.0% of its branches, 21 out of 28, during the tests.
 || Branch 12 taken: True || Branch 13 taken: True || Branch 14 taken: True || Branch 15 taken: True ||
 || Branch 16 taken: True || Branch 17 taken: True ||
 The subplot() function took 88.88888888888889% of its branches, 16 out of 18, during the tests.
+|| Branch 0 taken: True || Branch 1 taken: False || Branch 2 taken: True || Branch 3 taken: False ||
+|| Branch 4 taken: False || Branch 5 taken: False || Branch 6 taken: False || Branch 7 taken: False ||
+|| Branch 8 taken: True || Branch 9 taken: False || Branch 10 taken: False || Branch 11 taken: True ||
+|| Branch 12 taken: True || Branch 13 taken: True || Branch 14 taken: False ||
+The figure() function took 40.0% of its branches, 6 out of 15, during the tests.
 || Branch 0 taken: True || Branch 1 taken: True || Branch 2 taken: True || Branch 3 taken: True ||
 || Branch 4 taken: True || Branch 5 taken: True || Branch 6 taken: False || Branch 7 taken: True ||
 || Branch 8 taken: True || Branch 9 taken: False || Branch 10 taken: True || Branch 11 taken: False ||

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1125,142 +1125,8 @@ def cla():
 
 ## More ways of creating axes ##
 
-@_docstring.dedent_interpd
-def subplot(*args, **kwargs):
-    """
-    Add an Axes to the current figure or retrieve an existing Axes.
-
-    This is a wrapper of `.Figure.add_subplot` which provides additional
-    behavior when working with the implicit API (see the notes section).
-
-    Call signatures::
-
-       subplot(nrows, ncols, index, **kwargs)
-       subplot(pos, **kwargs)
-       subplot(**kwargs)
-       subplot(ax)
-
-    Parameters
-    ----------
-    *args : int, (int, int, *index*), or `.SubplotSpec`, default: (1, 1, 1)
-        The position of the subplot described by one of
-
-        - Three integers (*nrows*, *ncols*, *index*). The subplot will take the
-          *index* position on a grid with *nrows* rows and *ncols* columns.
-          *index* starts at 1 in the upper left corner and increases to the
-          right. *index* can also be a two-tuple specifying the (*first*,
-          *last*) indices (1-based, and including *last*) of the subplot, e.g.,
-          ``fig.add_subplot(3, 1, (1, 2))`` makes a subplot that spans the
-          upper 2/3 of the figure.
-        - A 3-digit integer. The digits are interpreted as if given separately
-          as three single-digit integers, i.e. ``fig.add_subplot(235)`` is the
-          same as ``fig.add_subplot(2, 3, 5)``. Note that this can only be used
-          if there are no more than 9 subplots.
-        - A `.SubplotSpec`.
-
-    projection : {None, 'aitoff', 'hammer', 'lambert', 'mollweide', \
-'polar', 'rectilinear', str}, optional
-        The projection type of the subplot (`~.axes.Axes`). *str* is the name
-        of a custom projection, see `~matplotlib.projections`. The default
-        None results in a 'rectilinear' projection.
-
-    polar : bool, default: False
-        If True, equivalent to projection='polar'.
-
-    sharex, sharey : `~.axes.Axes`, optional
-        Share the x or y `~matplotlib.axis` with sharex and/or sharey. The
-        axis will have the same limits, ticks, and scale as the axis of the
-        shared axes.
-
-    label : str
-        A label for the returned axes.
-
-    Returns
-    -------
-    `~.axes.Axes`
-
-        The Axes of the subplot. The returned Axes can actually be an instance
-        of a subclass, such as `.projections.polar.PolarAxes` for polar
-        projections.
-
-    Other Parameters
-    ----------------
-    **kwargs
-        This method also takes the keyword arguments for the returned axes
-        base class; except for the *figure* argument. The keyword arguments
-        for the rectilinear base class `~.axes.Axes` can be found in
-        the following table but there might also be other keyword
-        arguments if another projection is used.
-
-        %(Axes:kwdoc)s
-
-    Notes
-    -----
-    Creating a new Axes will delete any preexisting Axes that
-    overlaps with it beyond sharing a boundary::
-
-        import matplotlib.pyplot as plt
-        # plot a line, implicitly creating a subplot(111)
-        plt.plot([1, 2, 3])
-        # now create a subplot which represents the top plot of a grid
-        # with 2 rows and 1 column. Since this subplot will overlap the
-        # first, the plot (and its axes) previously created, will be removed
-        plt.subplot(211)
-
-    If you do not want this behavior, use the `.Figure.add_subplot` method
-    or the `.pyplot.axes` function instead.
-
-    If no *kwargs* are passed and there exists an Axes in the location
-    specified by *args* then that Axes will be returned rather than a new
-    Axes being created.
-
-    If *kwargs* are passed and there exists an Axes in the location
-    specified by *args*, the projection type is the same, and the
-    *kwargs* match with the existing Axes, then the existing Axes is
-    returned.  Otherwise a new Axes is created with the specified
-    parameters.  We save a reference to the *kwargs* which we use
-    for this comparison.  If any of the values in *kwargs* are
-    mutable we will not detect the case where they are mutated.
-    In these cases we suggest using `.Figure.add_subplot` and the
-    explicit Axes API rather than the implicit pyplot API.
-
-    See Also
-    --------
-    .Figure.add_subplot
-    .pyplot.subplots
-    .pyplot.axes
-    .Figure.subplots
-
-    Examples
-    --------
-    ::
-
-        plt.subplot(221)
-
-        # equivalent but more general
-        ax1 = plt.subplot(2, 2, 1)
-
-        # add a subplot with no frame
-        ax2 = plt.subplot(222, frameon=False)
-
-        # add a polar subplot
-        plt.subplot(223, projection='polar')
-
-        # add a red subplot that shares the x-axis with ax1
-        plt.subplot(224, sharex=ax1, facecolor='red')
-
-        # delete ax2 from the figure
-        plt.delaxes(ax2)
-
-        # add ax2 to the figure again
-        plt.subplot(ax2)
-
-        # make the first axes "current" again
-        plt.subplot(221)
-
-    """
-    # Here we will only normalize `polar=True` vs `projection='polar'` and let
-    # downstream code deal with the rest.
+# Check if one of the arguments polar and projection is given
+def _check_subplot(**kwargs):
     unset = object()
     projection = kwargs.get('projection', unset)
     polar = kwargs.pop('polar', unset)
@@ -1276,40 +1142,160 @@ def subplot(*args, **kwargs):
                 "Only one of these arguments should be supplied."
             )
         kwargs['projection'] = projection = 'polar'
+    return kwargs
 
-    # if subplot called without arguments, create subplot(1, 1, 1)
-    if len(args) == 0:  # branch 4
-        get_subplot_BranchBools[4] = True
-        args = (1, 1, 1)
-
-    # This check was added because it is very easy to type subplot(1, 2, False)
-    # when subplots(1, 2, False) was intended (sharex=False, that is). In most
-    # cases, no error will ever occur, but mysterious behavior can result
-    # because what was intended to be the sharex argument is instead treated as
-    # a subplot index for subplot()
-    if len(args) >= 3 and isinstance(args[2], bool):  # branch 5 and 6
+# This check was added because it is very easy to type subplot(1, 2, False)
+# when subplots(1, 2, False) was intended (sharex=False, that is). In most
+# cases, no error will ever occur, but mysterious behavior can result
+# because what was intended to be the sharex argument is instead treated as
+# a subplot index for subplot()
+def _check_subplot_confused_with_subplots(*args):
+    if len(args) >= 3 and isinstance(args[2], bool): #branch 5 and 6
         get_subplot_BranchBools[5] = True
         get_subplot_BranchBools[6] = True
         _api.warn_external("The subplot index argument to subplot() appears "
                            "to be a boolean. Did you intend to use "
                            "subplots()?")
-    # Check for nrows and ncols, which are not valid subplot args:
-    if 'nrows' in kwargs or 'ncols' in kwargs:  # branch 7 and 8
+
+# Check for nrows and ncols, which are not valid subplot args:
+def _check_nrows_and_ncols_for_subplot(**kwargs):
+    if 'nrows' in kwargs or 'ncols' in kwargs: #branch 7 and 8
         get_subplot_BranchBools[7] = True
-        if ('nrows' not in kwargs):
+        if('nrows' not in kwargs):
             get_subplot_BranchBools[8] = True
         raise TypeError("subplot() got an unexpected keyword argument 'ncols' "
                         "and/or 'nrows'.  Did you intend to call subplots()?")
+
+@_docstring.dedent_interpd
+def subplot(*args, **kwargs):
+    """
+    Add an Axes to the current figure or retrieve an existing Axes.
+    This is a wrapper of `.Figure.add_subplot` which provides additional
+    behavior when working with the implicit API (see the notes section).
+    Call signatures::
+       subplot(nrows, ncols, index, **kwargs)
+       subplot(pos, **kwargs)
+       subplot(**kwargs)
+       subplot(ax)
+    Parameters
+    ----------
+    *args : int, (int, int, *index*), or `.SubplotSpec`, default: (1, 1, 1)
+        The position of the subplot described by one of
+        - Three integers (*nrows*, *ncols*, *index*). The subplot will take the
+          *index* position on a grid with *nrows* rows and *ncols* columns.
+          *index* starts at 1 in the upper left corner and increases to the
+          right. *index* can also be a two-tuple specifying the (*first*,
+          *last*) indices (1-based, and including *last*) of the subplot, e.g.,
+          ``fig.add_subplot(3, 1, (1, 2))`` makes a subplot that spans the
+          upper 2/3 of the figure.
+        - A 3-digit integer. The digits are interpreted as if given separately
+          as three single-digit integers, i.e. ``fig.add_subplot(235)`` is the
+          same as ``fig.add_subplot(2, 3, 5)``. Note that this can only be used
+          if there are no more than 9 subplots.
+        - A `.SubplotSpec`.
+    projection : {None, 'aitoff', 'hammer', 'lambert', 'mollweide', \
+'polar', 'rectilinear', str}, optional
+        The projection type of the subplot (`~.axes.Axes`). *str* is the name
+        of a custom projection, see `~matplotlib.projections`. The default
+        None results in a 'rectilinear' projection.
+    polar : bool, default: False
+        If True, equivalent to projection='polar'.
+    sharex, sharey : `~.axes.Axes`, optional
+        Share the x or y `~matplotlib.axis` with sharex and/or sharey. The
+        axis will have the same limits, ticks, and scale as the axis of the
+        shared axes.
+    label : str
+        A label for the returned axes.
+    Returns
+    -------
+    `~.axes.Axes`
+        The Axes of the subplot. The returned Axes can actually be an instance
+        of a subclass, such as `.projections.polar.PolarAxes` for polar
+        projections.
+    Other Parameters
+    ----------------
+    **kwargs
+        This method also takes the keyword arguments for the returned axes
+        base class; except for the *figure* argument. The keyword arguments
+        for the rectilinear base class `~.axes.Axes` can be found in
+        the following table but there might also be other keyword
+        arguments if another projection is used.
+        %(Axes:kwdoc)s
+    Notes
+    -----
+    Creating a new Axes will delete any preexisting Axes that
+    overlaps with it beyond sharing a boundary::
+        import matplotlib.pyplot as plt
+        # plot a line, implicitly creating a subplot(111)
+        plt.plot([1, 2, 3])
+        # now create a subplot which represents the top plot of a grid
+        # with 2 rows and 1 column. Since this subplot will overlap the
+        # first, the plot (and its axes) previously created, will be removed
+        plt.subplot(211)
+    If you do not want this behavior, use the `.Figure.add_subplot` method
+    or the `.pyplot.axes` function instead.
+    If no *kwargs* are passed and there exists an Axes in the location
+    specified by *args* then that Axes will be returned rather than a new
+    Axes being created.
+    If *kwargs* are passed and there exists an Axes in the location
+    specified by *args*, the projection type is the same, and the
+    *kwargs* match with the existing Axes, then the existing Axes is
+    returned.  Otherwise a new Axes is created with the specified
+    parameters.  We save a reference to the *kwargs* which we use
+    for this comparison.  If any of the values in *kwargs* are
+    mutable we will not detect the case where they are mutated.
+    In these cases we suggest using `.Figure.add_subplot` and the
+    explicit Axes API rather than the implicit pyplot API.
+    See Also
+    --------
+    .Figure.add_subplot
+    .pyplot.subplots
+    .pyplot.axes
+    .Figure.subplots
+    Examples
+    --------
+    ::
+        plt.subplot(221)
+        # equivalent but more general
+        ax1 = plt.subplot(2, 2, 1)
+        # add a subplot with no frame
+        ax2 = plt.subplot(222, frameon=False)
+        # add a polar subplot
+        plt.subplot(223, projection='polar')
+        # add a red subplot that shares the x-axis with ax1
+        plt.subplot(224, sharex=ax1, facecolor='red')
+        # delete ax2 from the figure
+        plt.delaxes(ax2)
+        # add ax2 to the figure again
+        plt.subplot(ax2)
+        # make the first axes "current" again
+        plt.subplot(221)
+    """
+
+    # Here we will only normalize `polar=True` vs `projection='polar'` and let
+    # downstream code deal with the rest.
+    kwargs = _check_subplot(**kwargs)
+
+    # if subplot called without arguments, create subplot(1, 1, 1)
+    if len(args) == 0: #branch 4
+        get_subplot_BranchBools[4] = True
+        args = (1, 1, 1)
+
+    # check if subplot confused with subplots according to the given arguments
+    _check_subplot_confused_with_subplots(*args)
+
+    # Check for nrows and ncols, which are not valid subplot args:
+    _check_nrows_and_ncols_for_subplot(**kwargs)
 
     fig = gcf()
 
     # First, search for an existing subplot with a matching spec.
     key = SubplotSpec._from_subplot_args(fig, args)
 
-    for ax in fig.axes:  # branch 9
+    for ax in fig.axes: #branch 9
         get_subplot_BranchBools[9] = True
         # if we found an Axes at the position sort out if we can re-use it
-        if ax.get_subplotspec() == key:  # branch 10
+        if ax.get_subplotspec() == key: #branch 10
             get_subplot_BranchBools[10] = True
             # if the user passed no kwargs, re-use
             if kwargs == {}:
@@ -1317,32 +1303,32 @@ def subplot(*args, **kwargs):
                 break
             # if the axes class and kwargs are identical, reuse
             elif ax._projection_init == fig._process_projection_requirements(
-                    *args, **kwargs
-            ):  # branch 11
+                *args, **kwargs
+            ): #branch 11
                 get_subplot_BranchBools[11] = True
                 break
-    else:  # branch 12
+    else: #branch 12
         get_subplot_BranchBools[12] = True
         # we have exhausted the known Axes and none match, make a new one!
         ax = fig.add_subplot(*args, **kwargs)
 
     fig.sca(ax)
 
-    axes_to_delete = [other for other in fig.axes  # branch 13
-                      if other != ax and ax.bbox.fully_overlaps(other.bbox)]  # branch 14 and 15
-    if (len(fig.axes) != 0):
+    axes_to_delete = [other for other in fig.axes #branch 13
+                      if other != ax and ax.bbox.fully_overlaps(other.bbox)] #branch 14 and 15
+    if(len(fig.axes) != 0):
         get_subplot_BranchBools[13] = True
-    if (len(axes_to_delete) != 0):
+    if(len(axes_to_delete) != 0):
         get_subplot_BranchBools[14] = True
         get_subplot_BranchBools[15] = True
 
-    if axes_to_delete:  # branch 16
+    if axes_to_delete: #branch 16
         get_subplot_BranchBools[16] = True
         _api.warn_deprecated(
             "3.6", message="Auto-removal of overlapping axes is deprecated "
-                           "since %(since)s and will be removed %(removal)s; explicitly call "
-                           "ax.remove() as needed.")
-    for ax_to_del in axes_to_delete:  # branch 17
+            "since %(since)s and will be removed %(removal)s; explicitly call "
+            "ax.remove() as needed.")
+    for ax_to_del in axes_to_delete: #branch 17
         get_subplot_BranchBools[17] = True
         delaxes(ax_to_del)
 

--- a/lib/matplotlib/tests/test_pyplot_ronan.py
+++ b/lib/matplotlib/tests/test_pyplot_ronan.py
@@ -31,7 +31,7 @@ def test_figure_not_managed_by_pyplot():
         plt.figure(num=fig)
     assert str(excinfo.value) == "The passed figure is not managed by pyplot"
 
-# if num is an instance of str
+# if num is an instance of str and str = "all" then we should throw a warning
 def test_figure_with_num_str():
      with pytest.warns(UserWarning) as warninginfo:
         plt.figure("all")


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
